### PR TITLE
feat: add TWZRD Agent Intel MCP for GenAI cybersecurity agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This section covers resources related to Model Context Protocol (MCP) servers fo
 
 ---
 
+* 🖥️ [TWZRD Agent Intel MCP](https://intel.twzrd.xyz) **[Live]** - On-chain behavioral trust scoring MCP server for GenAI cybersecurity agents on Solana. Verify AI agent wallet identity and behavioral track record before granting access to sensitive security data. Tools: `score_agent`, `preflight_check`, `get_trust_receipt`. Free endpoint: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 ### 🥈 Models
 
 * 🧠 [SecureBERT](https://huggingface.co/ehsanaghaei/SecureBERT) **[Model/HuggingFace]** - A BERT model pre-trained on a vast corpus of cybersecurity texts.


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the MCP Servers section.

TWZRD Agent Intel is a trust scoring MCP server for GenAI cybersecurity agents on Solana. In AI-driven security operations, verifying that the AI agent you're trusting with sensitive data hasn't been compromised is critical. This MCP scores agent wallet behavioral history on-chain.

**Tools:** `score_agent(wallet)`, `preflight_check(wallet)`, `get_trust_receipt(wallet)`

**MCP Config:** `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`