### PR TITLE
feat: add AI-driven threat hunting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Welcome to **Awesome GenAI CyberHub**, your focused repository for Agentic AI La
   - [Malware Analysis](./Resources/malware-analysis/README.md)
   - [Vulnerability Analysis](./Resources/vulnerability-analysis/README.md)
   - [Detection Engineering](./Resources/detection-engineering/README.md)
+  - [AI-Driven Threat Hunting](./Resources/threat-hunting/README.md)
   - [Phishing Analysis](./Resources/phishing-analysis/README.md)
   - [LLM-Based Honeypots](./Resources/honeypots/README.md)
   - [Offensive Security](./Resources/offensive-security/README.md)
@@ -72,6 +73,7 @@ awesome-genai-cyberhub/
    ├── malware-analysis/      # LLM driven malware Analysis
    ├── vulnerability-analysis/ # LLMs in vuln discovery
    ├── detection-engineering/ # Generative AI rule writing & alerts
+   ├── threat-hunting/        # AI-driven threat hunting & hypothesis gen
    ├── phishing-analysis/     # Phishing Analysis & detection
    ├── honeypots/             # LLM-driven honeypot frameworks
    ├── offensive-security/    # Offensive security workflows

--- a/Resources/ai-soc/README.md
+++ b/Resources/ai-soc/README.md
@@ -50,8 +50,6 @@ Welcome to the **AI SOC** section of Awesome GenAI CyberHub! This space is dedic
 
 * 📰 [Integrating LLMs into security operations using Wazuh (Bleeping Computer)](https://www.bleepingcomputer.com/news/security/integrating-llms-into-security-operations-using-wazuh/) **[Article]**  *(Published February 20, 2025)*
 
-* [Using Microsoft Sentinel MCP Server with GitHub Copilot for AI-Powered Threat Hunting](https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/using-microsoft-sentinel-mcp-server-with-github-copilot-for-ai-powered-threat-hu/4464980) **[Blog]**
-
 * [AI Runbooks for Google SecOps: Security Operations with Model Context Protocol (Google Cloud Community)](https://www.googlecloudcommunity.com/gc/Community-Blog/AI-Runbooks-for-Google-SecOps-Security-Operations-with-Model/ba-p/906723) **[Blog]**
 
 * [A step-by-step guide to SOC automation (Threat hunting & incident response lab)](https://detect.fyi/step-by-step-guide-soc-automation-smb-threat-hunting-incident-response-lab-b6e48da2750d) **[Blog]**
@@ -73,8 +71,6 @@ Welcome to the **AI SOC** section of Awesome GenAI CyberHub! This space is dedic
 * [Tracecat (v0.36.0)](https://github.com/TracecatHQ/tracecat) **[Tool/GitHub]** - Automation/orchestration building block for security operations workflows.
 
 * [neuroSOC](https://github.com/sarahsolieman/neuroSOC) **[Tool/GitHub]** - Agentic SOC/DFIR-oriented experimentation project.
-
-* [PEAK-Assistant](https://github.com/cisco-foundation-ai/PEAK-Assistant) **[Tool/GitHub]** - AI-backed threat hunting assistant aligned to the PEAK framework, with MCP and SIEM-driven hunt planning workflows.
 
 * 🛠️ [Vigil (Vigil-SOC)](https://github.com/Vigil-SOC/vigil) **[Tool/GitHub]** - Open-source AI SOC platform with 13 specialized agents (triage, investigate, respond, report) built on the Claude Agent SDK and MCP. Apache 2.0 licensed, fully inspectable agent reasoning. Website: [vigilsoc.org](https://vigilsoc.org).
 

--- a/Resources/detection-engineering/README.md
+++ b/Resources/detection-engineering/README.md
@@ -13,7 +13,7 @@ Welcome to the **Detection Engineering** section of Awesome GenAI CyberHub! This
 
 * [Audit-LLM: Multi-Agent Collaboration for Log-based Insider Threat Detection](https://arxiv.org/pdf/2408.08902v1) **[Paper]** - Introduces Audit-LLM, a multi-agent framework for log-based insider threat detection using LLMs, featuring a Decomposer agent, Tool Builder agent, and Executor agents with an Evidence-based Multi-agent Debate (EMAD) mechanism.
 
-* [LLMCloudHunter: Harnessing LLMs for Automated Extraction of Detection Rules from Cloud-Based CTI](https://arxiv.org/pdf/2407.05194) **[Paper]** - Proposes LLMCloudHunter, a framework leveraging LLMs to automatically generate detection rule candidates from textual and visual open-source cloud threat intelligence (OS-CTI) data.
+* [LLMCloudHunter: Harnessing LLMs for Automated Extraction of Detection Rules from Cloud-Based CTI (arXiv:2407.05194)](https://arxiv.org/abs/2407.05194) **[Paper]** - Leverages LLMs to automatically generate detection rule candidates from cloud-based CTI, achieving 92% precision / 98% recall with direct SPL output. *(See also: [AI-Driven Threat Hunting](../threat-hunting/README.md))*
 
 * [The Always-On Purple Team: An Automated CI/CD for Detection Engineering (RSA Conference 2024)](https://static.rainfocus.com/rsac/us24/sess/1696325909809001qy71/finalwebsite/2024_USA24_HTA-M03_01_The-Always-On-Purple-Team-An-Automated-CICD-for-Detection-Engineering_1713983129840001qmBZ.pdf) **[Paper/Presentation]** - Presents an architecture merging SOC technologies (SIEM/XDR, SOAR, BAS, ChatGPT) into a detection engineering CI/CD pipeline for automatic creation, testing, and deployment of detection analytics.
 
@@ -32,9 +32,9 @@ Welcome to the **Detection Engineering** section of Awesome GenAI CyberHub! This
 
 * 📰 [Effectiveness of LLMs for Detection Research (Cisco Talos Whitepaper)](https://blog.talosintelligence.com/content/files/2024/10/LLM-Detection-Whitepaper.pdf) **[Whitepaper]** - A whitepaper from Cisco Talos detailing research into how LLMs can assist defenders in writing more effective detection content and improving the detection research process.
 
-* [Evolving the Threat Hunter Playbook: planning hunts with agent skills (Open Threat Research Blog)](https://blog.openthreatresearch.com/evolving-the-threat-hunter-playbook-planning-hunts-with-agent-skills/) **[Blog]** - Hunt planning methodology leveraging agent skills to structure investigations.
+* [Evolving the Threat Hunter Playbook: planning hunts with agent skills (Open Threat Research Blog)](https://blog.openthreatresearch.com/evolving-the-threat-hunter-playbook-planning-hunts-with-agent-skills/) **[Blog]** - Hunt planning methodology leveraging agent skills to structure investigations. *(See also: [AI-Driven Threat Hunting](../threat-hunting/README.md))*
 
-* [Teaching AI agents your organization (Detection at Scale)](https://www.detectionatscale.com/p/teaching-ai-agents-your-organization) **[Blog]**
+* [Teaching AI agents your organization (Detection at Scale)](https://www.detectionatscale.com/p/teaching-ai-agents-your-organization) **[Blog]** *(See also: [AI-Driven Threat Hunting](../threat-hunting/README.md))*
 
 * 📰 [Detection Engineering AI Maturity Framework](https://infosecb.github.io/detection-engineering-ai-maturity/) **[Framework/Site]** - A community framework for assessing how organizations apply AI and large language models across a detection engineering program.
 

--- a/Resources/threat-hunting/README.md
+++ b/Resources/threat-hunting/README.md
@@ -1,0 +1,38 @@
+# 🎯 AI-Driven Threat Hunting
+
+> A curated collection of Large Language Model (LLM) resources focused on **autonomous, AI-assisted, and agentic threat hunting** — from hypothesis generation to SIEM query automation.
+
+Welcome to the **AI-Driven Threat Hunting** section of Awesome GenAI CyberHub! This space is dedicated to exploring how LLMs are being used to proactively hunt for threats, generate hypotheses from threat intelligence, auto-generate hunting queries (KQL, SPL, etc.), and structure the full threat hunting lifecycle using AI agents.
+
+---
+
+## ✅ Curated Resources
+
+
+### 📜 Research Papers
+
+* 📄 [LLMCloudHunter: Harnessing LLMs for Automated Extraction of Detection Rules from Cloud-Based CTI (arXiv:2407.05194)](https://arxiv.org/abs/2407.05194) **[Paper]** - Leverages LLMs to automatically generate detection rule candidates from textual and visual open-source cloud threat intelligence. Achieves 92% precision and 98% recall on cloud threat reports, converting results directly to Splunk SPL queries.
+
+* 📄 [iThelma: An Autonomous LLM Agent for Cyber Threat Hunting via Playbook-Driven Intelligence (IEEE CNS 2025)](https://ieeexplore.ieee.org/document/11195050/) **[Paper]** - Presents iThelma, an autonomous LLM agent that integrates structured threat hunting playbooks with LLM reasoning to automate script generation, validation, and adaptive learning for enterprise-scale threat hunting. DOI: 10.1109/CNS66487.2025.11195050.
+
+
+### 🛠️ Tools & Frameworks
+
+* 🛠️ [PEAK-Assistant (Cisco Talos)](https://github.com/cisco-foundation-ai/PEAK-Assistant) **[Tool/GitHub]** - AI-backed threat hunting assistant aligned to the PEAK framework (Prepare, Execute, Act, Knowledge), with MCP and SIEM-driven hunt planning workflows for structured, reproducible investigations.
+
+* 🛠️ [Watcher (thalesgroup-cert)](https://github.com/thalesgroup-cert/Watcher) **[Tool/GitHub]** - Open-source AI-powered Cyber Threat Intelligence & hunting platform (Django + React JS). Provides AI-driven threat intel digests, CVE/ransomware tracking, domain surveillance, IOC correlation, and integrations with TheHive and MISP. AGPL-3.0 licensed. 1.3k+ GitHub stars.
+
+
+### 📚 Articles & Blog Posts
+
+* 📰 [Evolving the Threat Hunter Playbook: planning hunts with agent skills (Open Threat Research Blog)](https://blog.openthreatresearch.com/evolving-the-threat-hunter-playbook-planning-hunts-with-agent-skills/) **[Blog]** - Hunt planning methodology leveraging agent skills to structure investigations using the PEAK framework.
+
+* 📰 [Using Microsoft Sentinel MCP Server with GitHub Copilot for AI-Powered Threat Hunting](https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/using-microsoft-sentinel-mcp-server-with-github-copilot-for-ai-powered-threat-hu/4464980) **[Blog]** - Demonstrates using Microsoft Sentinel's MCP server with GitHub Copilot to perform AI-powered threat hunting queries.
+
+* 📰 [Teaching AI agents your organization (Detection at Scale)](https://www.detectionatscale.com/p/teaching-ai-agents-your-organization) **[Blog]** - Explores how to give AI agents the organizational context they need to hunt effectively within your specific environment.
+
+---
+
+## Navigate Back
+
+* [Back to Awesome GenAI CyberHub Main Page](../../README.md)


### PR DESCRIPTION
- Create Resources/threat-hunting/README.md with:
  - iThelma paper (IEEE CNS 2025, autonomous LLM threat hunting)
  - LLMCloudHunter paper (cloud CTI → detection rules, 92% precision)
  - PEAK-Assistant tool (Cisco Talos, PEAK framework + MCP)
  - Watcher tool (Thalesgroup, AI-powered CTI & hunting platform)
  - Evolving the Threat Hunter Playbook blog
  - Sentinel MCP + Copilot blog
  - Teaching AI agents your organization blog
- Migrate PEAK-Assistant and Sentinel MCP blog out of ai-soc
- Update detection-engineering entries with cross-reference links
- Fix LLMCloudHunter URL from /pdf/ to /abs/
- Update root README: ToC and directory tree